### PR TITLE
support number representation at sublevel

### DIFF
--- a/src/interpreter/interpreter.test.ts
+++ b/src/interpreter/interpreter.test.ts
@@ -1,7 +1,7 @@
 import interpreter from './interpreter';
 
 function t(expression: string, expected: string) {
-  test(expression, () => {
+  test(`${expression} => ${expected}`, () => {
     expect(interpreter(expression)).toBe(expected);
   });
 }
@@ -23,3 +23,4 @@ t('5 in binary', '0b101');
 t('1+2+3 in binary', '0b110');
 t('1 in binary + 6', '0b111');
 // t('0b101 in decimal', '5'); Todo: Handle conversion to decimal
+t('1.5+0.33', '1.83');

--- a/src/interpreter/interpreter.test.ts
+++ b/src/interpreter/interpreter.test.ts
@@ -44,11 +44,13 @@ test.skip('divide by', () => {
   expect(interpreter('4 divide by 2')).toBe('2');
 });
 
-describe('binary', () => {
-  test('number to binary', () =>
+describe('representation', () => {
+  test('decimal to binary', () =>
     expect(interpreter('5 in binary')).toBe('0b101'));
   test('expression to binary', () =>
     expect(interpreter('1+2+3 in binary')).toBe('0b110'));
-  test('number representation propagation', () =>
+  test('propagation', () =>
     expect(interpreter('1 in binary + 6')).toBe('0b111'));
+  test.skip('binary to decimal', () =>
+    expect(interpreter('0b101 in decimal')).toBe('5'));
 });

--- a/src/interpreter/interpreter.test.ts
+++ b/src/interpreter/interpreter.test.ts
@@ -49,8 +49,6 @@ describe('binary', () => {
     expect(interpreter('5 in binary')).toBe('0b101'));
   test('expression to binary', () =>
     expect(interpreter('1+2+3 in binary')).toBe('0b110'));
-
-  // Todo
-  test.skip('number representation propagation', () =>
+  test('number representation propagation', () =>
     expect(interpreter('1 in binary + 6')).toBe('0b111'));
 });

--- a/src/interpreter/interpreter.test.ts
+++ b/src/interpreter/interpreter.test.ts
@@ -1,56 +1,25 @@
 import interpreter from './interpreter';
 
-test('addition', () => {
-  expect(interpreter('1+2')).toBe('3');
-});
+function t(expression: string, expected: string) {
+  test(expression, () => {
+    expect(interpreter(expression)).toBe(expected);
+  });
+}
 
-test('substraction', () => {
-  expect(interpreter('2-1')).toBe('1');
-});
-
-test('multiplication', () => {
-  expect(interpreter('2+1*3')).toBe('5');
-});
-
-test('division', () => {
-  expect(interpreter('10-2/4')).toBe('9.5');
-});
-
-test('parenthesis', () => {
-  expect(interpreter('(10-2)/4*(3+1)')).toBe('8');
-});
-
-test('unary plus and minus', () => {
-  expect(interpreter('-(10-2)+(+3)')).toBe('-5');
-});
-
-test('exponent', () => {
-  expect(interpreter('2^3')).toBe('8');
-  expect(interpreter('2^3^4')).toBe('4096');
-  expect(interpreter('2*2^3')).toBe('16');
-});
-
-test('white space', () => {
-  expect(interpreter('  ( 2 + 3 )  ')).toBe('5');
-});
-
-test('plus', () => {
-  expect(interpreter('1plus2')).toBe('3');
-  expect(interpreter('1 plus 2')).toBe('3');
-});
-
-// Todo: Handle composite keywords
-test.skip('divide by', () => {
-  expect(interpreter('4 divide by 2')).toBe('2');
-});
-
-describe('representation', () => {
-  test('decimal to binary', () =>
-    expect(interpreter('5 in binary')).toBe('0b101'));
-  test('expression to binary', () =>
-    expect(interpreter('1+2+3 in binary')).toBe('0b110'));
-  test('propagation', () =>
-    expect(interpreter('1 in binary + 6')).toBe('0b111'));
-  test.skip('binary to decimal', () =>
-    expect(interpreter('0b101 in decimal')).toBe('5'));
-});
+t('1+2', '3');
+t('2-1', '1');
+t('2+1*3', '5');
+t('10-2/4', '9.5');
+t('(10-2)/4*(3+1)', '8');
+t('-(10-2)+(+3)', '-5');
+t('2^3', '8');
+t('2^3^4', '4096');
+t('2*2^3', '16');
+t('  ( 2 + 3 )  ', '5');
+t('1plus2', '3');
+t('1 plus 2', '3');
+// t('4 divide by 2','2'); Todo: Handle composite keywords
+t('5 in binary', '0b101');
+t('1+2+3 in binary', '0b110');
+t('1 in binary + 6', '0b111');
+// t('0b101 in decimal', '5'); Todo: Handle conversion to decimal

--- a/src/interpreter/interpreter.ts
+++ b/src/interpreter/interpreter.ts
@@ -7,44 +7,105 @@ import parser, {
   Expression,
 } from './parser';
 
+enum Representation {
+  Unknown,
+  Decimal,
+  Binary,
+}
+
+type ExpressionResult = {
+  value: number;
+  representation: Representation;
+};
+
+function mergeRepresentation(
+  left: Representation,
+  right: Representation
+): Representation {
+  if (left === Representation.Unknown) {
+    return right;
+  }
+  if (right === Representation.Unknown) {
+    return left;
+  }
+  return right;
+}
+
+function display(er: ExpressionResult): string {
+  switch (er.representation) {
+    case Representation.Unknown:
+    case Representation.Decimal:
+      return er.value.toString();
+    case Representation.Binary:
+      return '0b' + er.value.toString(2);
+    default:
+      throw new Error(`Unknown number representation: ${er.representation}`);
+  }
+}
+
 function evaluate(ast: Node): string {
-  function visit(node: Expression) {
+  function visit(node: Expression): ExpressionResult {
     switch (node.kind) {
       case NodeKind.UnaryPlus:
         return visit(node.expression);
       case NodeKind.UnaryMinus:
-        return -visit(node.expression);
+        const result = visit(node.expression);
+        return {
+          value: -result.value,
+          representation: result.representation,
+        };
       case NodeKind.BinaryExpression:
         return visitBinaryExpression(node);
       case NodeKind.NumberLiteral:
         return visitNumberLiteral(node);
       case NodeKind.ConvertToBinaryNumber:
-        return '0b' + visit(node.expression).toString(2);
+        return {
+          ...visit(node.expression),
+          representation: Representation.Binary,
+        };
       default:
         throw new Error(`Unexpected node kind: ${node}`);
     }
   }
 
-  function visitBinaryExpression(node: BinaryExpression) {
-    switch (node.operator) {
+  function binaryOperatorToFunction(
+    operator: '+' | '-' | '*' | '/' | '^'
+  ): (l: number, r: number) => number {
+    switch (operator) {
       case '+':
-        return visit(node.left) + visit(node.right);
+        return (l, r) => l + r;
       case '-':
-        return visit(node.left) - visit(node.right);
+        return (l, r) => l - r;
       case '*':
-        return visit(node.left) * visit(node.right);
+        return (l, r) => l * r;
       case '/':
-        return visit(node.left) / visit(node.right);
+        return (l, r) => l / r;
       case '^':
-        return Math.pow(visit(node.left), visit(node.right));
+        return Math.pow;
     }
   }
 
-  function visitNumberLiteral(node: NumberLiteral) {
-    return node.value;
+  function visitBinaryExpression(node: BinaryExpression): ExpressionResult {
+    const left = visit(node.left);
+    const right = visit(node.right);
+
+    return {
+      value: binaryOperatorToFunction(node.operator)(left.value, right.value),
+      representation: mergeRepresentation(
+        left.representation,
+        right.representation
+      ),
+    };
   }
 
-  return visit(ast).toString();
+  function visitNumberLiteral(node: NumberLiteral): ExpressionResult {
+    return {
+      value: node.value,
+      representation: Representation.Unknown,
+    };
+  }
+
+  return display(visit(ast));
 }
 
 export default function(input: string): string {

--- a/src/interpreter/parser.ts
+++ b/src/interpreter/parser.ts
@@ -101,15 +101,34 @@ export default function parser(tokens: Token[]): Node {
     throw Error(`Unexpected token : ${token}`);
   }
 
-  function exponent(): Expression {
+  function conversion() {
     let node: Expression = factor();
+
+    if (currentToken().kind === SyntaxKind.In) {
+      consumeToken(SyntaxKind.In);
+
+      if (currentToken().kind === SyntaxKind.Binary) {
+        consumeToken(SyntaxKind.Binary);
+        node = {
+          kind: NodeKind.ConvertToBinaryNumber,
+          expression: node,
+        };
+      } else {
+        throw new Error(`Can't extract unit from token ${currentToken()}`);
+      }
+    }
+    return node;
+  }
+
+  function exponent(): Expression {
+    let node: Expression = conversion();
 
     let token = currentToken();
 
     while (true) {
       if (token.kind === SyntaxKind.CaretToken) {
         consumeToken(SyntaxKind.CaretToken);
-        node = makeBinaryExpression(node, '^', factor());
+        node = makeBinaryExpression(node, '^', conversion());
       } else {
         break;
       }
@@ -161,25 +180,5 @@ export default function parser(tokens: Token[]): Node {
     return node;
   }
 
-  function conversion() {
-    let node: Expression = expr();
-
-    if (currentToken().kind === SyntaxKind.In) {
-      consumeToken(SyntaxKind.In);
-
-      if (currentToken().kind === SyntaxKind.Binary) {
-        consumeToken(SyntaxKind.Binary);
-        node = {
-          kind: NodeKind.ConvertToBinaryNumber,
-          expression: node,
-        };
-      } else {
-        throw new Error(`Can't extract unit from token ${currentToken()}`);
-      }
-    }
-
-    return node;
-  }
-
-  return conversion();
+  return expr();
 }

--- a/src/interpreter/parser.ts
+++ b/src/interpreter/parser.ts
@@ -65,7 +65,7 @@ export default function parser(tokens: Token[]): Node {
   function makeNumberLiteral(token: NumberToken): NumberLiteral {
     return {
       kind: NodeKind.NumberLiteral,
-      value: parseInt(token.value),
+      value: parseFloat(token.value),
     };
   }
 

--- a/src/interpreter/tokenizer.ts
+++ b/src/interpreter/tokenizer.ts
@@ -64,6 +64,24 @@ function extractNextKeyword(input: string, current: number): string {
   return keyword;
 }
 
+function extractNumber(input: string, current: number): string {
+  let value = '';
+  let hasDecimals = false;
+
+  while (input[current]) {
+    if (isDigit(input[current])) {
+      value += input[current];
+    } else if (input[current] === '.' && !hasDecimals) {
+      value += '.';
+      hasDecimals = true;
+    } else {
+      break;
+    }
+    current++;
+  }
+  return value;
+}
+
 export default function tokenizer(input: string): Token[] {
   let current = 0;
 
@@ -79,12 +97,12 @@ export default function tokenizer(input: string): Token[] {
       });
       current++;
     } else if (isDigit(char)) {
-      let value = '';
-      while (isDigit(char)) {
-        value += char;
-        char = input[++current];
-      }
-      tokens.push({ kind: SyntaxKind.Number, value } as NumberToken);
+      var numberAsString = extractNumber(input, current);
+      current += numberAsString.length;
+      tokens.push({
+        kind: SyntaxKind.Number,
+        value: numberAsString,
+      } as NumberToken);
     } else if (isLetter(char)) {
       const keyword = extractNextKeyword(input, current);
       const syntaxKind = keywordToSyntaxKindMap.get(keyword);


### PR DESCRIPTION
Just for clarification, priority ranking:

Parenthesis > Conversion > Exponent > * and / by > + and -

Now, the `visit` function return a number and a representation. It allows us to propagate the representation until final display.

Let me know if you have any questions